### PR TITLE
Use explicit radix for js/parseInt

### DIFF
--- a/src/taoensso/encore.cljx
+++ b/src/taoensso/encore.cljx
@@ -309,7 +309,7 @@
 
     #+cljs
     (cond (number? x) (long x)
-          (string? x) (let [x (js/parseInt x)]
+          (string? x) (let [x (js/parseInt x 10)]
                         (when-not (js/isNaN x) x))
           :else        nil)))
 


### PR DESCRIPTION
Unlike Long/parseLong, js/parseInt without an explicit radix is not the same as specifying radix 10. If the string starts with "0x" it will be parsed as hex, if it starts with "0" it may be parsed either as octal or decimal, depending on the browser. Thus the advice "never use parseInt without explicit radix".
