### PR TITLE
Add clj-kondo hook for defn-cached

### DIFF
--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -1,1 +1,2 @@
-{:hooks {:analyze-call {taoensso.encore/defalias taoensso.encore/defalias}}}
+{:hooks {:analyze-call {taoensso.encore/defalias    taoensso.encore/defalias
+                        taoensso.encore/defn-cached taoensso.encore/defn-cached}}}

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
@@ -14,3 +14,15 @@
                 (hooks/token-node (hooks/sexpr sym))
                 (hooks/token-node (hooks/sexpr src))])
              (meta src))}))
+
+(defn defn-cached [{:keys [node] :as x}]
+  (let [[sym _opts binding-vec & body] (rest (:children node))]
+    {:node (hooks/list-node
+            (list
+             (hooks/token-node 'def)
+             sym
+             (hooks/list-node
+              (list*
+               (hooks/token-node 'fn)
+               binding-vec
+               body))))}))


### PR DESCRIPTION
Hi,

I'm following up with an addition to the initial clj-kondo support that was added to the repo in [this PR](https://github.com/taoensso/encore/commit/8e11f4d44cc30dd7e3594ff5d1cabcd1f465ec18).

without this hook in place if you run clj-kondo on a clojure file that defines this function using `encore/defn-cached`:

```
(enc/defn-cached example-fn {:ttl 30000}
  [i]
  (Thread/sleep 1000)
  (inc i))
```

clj-kondo would error out with these two errors:

```
error: Unresolved symbol: example-fn
error: Unresolved symbol: i
```

The hook in this commit translates the `defn-cached` example above into

```
(def example-fn
  (fn [i]
    (Thread/sleep 1000)
    (inc i)))
```

before running the clj-kondo linting step.