### PR TITLE
Add clj-kondo hook for `defonce`

### DIFF
--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -1,4 +1,5 @@
 {:hooks
  {:analyze-call
   {taoensso.encore/defalias    taoensso.encore/defalias
-   taoensso.encore/defn-cached taoensso.encore/defn-cached}}}
+   taoensso.encore/defn-cached taoensso.encore/defn-cached
+   taoensso.encore/defonce     taoensso.encore/defonce}}}

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
@@ -1,19 +1,15 @@
 (ns taoensso.encore
-  "I don't personally use clj-kondo, so these hooks are
-  kindly authored and maintained by contributors.
-  PRs very welcome! - Peter Taoussanis"
+  "I don't personally use clj-kondo, so these hooks are kindly authored
+   and maintained by contributors. PRs very welcome! - Peter Taoussanis"
+  (:refer-clojure :exclude [defonce])
   (:require
-   [clj-kondo.hooks-api :as hooks]))
+    [clj-kondo.hooks-api :as hooks]))
 
 (defn defalias
   [{:keys [node]}]
   (let [[sym-raw src-raw] (rest (:children node))
-        src (if src-raw src-raw sym-raw)
-        sym
-        (if src-raw
-          sym-raw
-          (symbol (name (hooks/sexpr src))))]
-
+        src (or src-raw sym-raw)
+        sym (if src-raw sym-raw (symbol (name (hooks/sexpr src))))]
     {:node
      (with-meta
        (hooks/list-node
@@ -23,7 +19,7 @@
        (meta src))}))
 
 (defn defn-cached
-  [{:keys [node] :as x}]
+  [{:keys [node]}]
   (let [[sym _opts binding-vec & body] (rest (:children node))]
     {:node
      (hooks/list-node
@@ -35,3 +31,17 @@
              (hooks/token-node 'fn)
              binding-vec
              body))))}))
+
+(defn defonce
+  [{:keys [node]}]
+  ;; args = [sym doc-string? attr-map? init-expr]
+  (let [[sym & args] (rest (:children node))
+        [doc-string args] (if (and (hooks/string-node? (first args)) (next args)) [(hooks/sexpr (first args)) (next args)] [nil args])
+        [attr-map init-expr] (if (and (hooks/map-node? (first args)) (next args)) [(hooks/sexpr (first args)) (fnext args)] [nil (first args)])
+        attr-map (if doc-string (assoc attr-map :doc doc-string) attr-map)
+        sym+meta (if attr-map (with-meta sym attr-map) sym)
+        rewritten (hooks/list-node
+                    [(hooks/token-node 'clojure.core/defonce)
+                     sym+meta
+                     init-expr])]
+    {:node rewritten}))


### PR DESCRIPTION
Hi Peter!

Adding yet another hook for `clj-kondo` here.

### Before

Having, for instance:
```
(encore/defonce v-thread-executor
  "..."
  {:private true
   :tag     'java.util.concurrent.ExecutorService}
  (knit/executor :virtual {:thread-factory v-thread-factory}))
```

produces the following `clj-kondo --lint` result:
```
error: Unresolved symbol: v-thread-executor
```

Which is not cool, right?

### After

A new hook translates the `defonce` example above into:
```
(clojure.core/defonce v-thread-executor (knit/executor :virtual {:thread-factory v-thread-factory}))
```
with all the metadata
```
{:private true, :tag (quote java.util.concurrent.ExecutorService), :doc "..."}
```
being [appropriately set](https://github.com/clj-kondo/clj-kondo/blob/e5ea549212615040fea2c88e2bfd601b6b2b969b/doc/config.md#clojure-code-as-rewrite-clj-nodes) to the `v-thread-executor` token node.

This eliminates the aforementioned error.

Cheers,
Mark