### PR TITLE
fix reseeding-srng with Java8+

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,14 +13,14 @@
   :javac-options     ["--release" "8" "-g"] ; Support Java >= v8
   :dependencies
   [[org.clojure/tools.reader "1.4.2"]
-   [com.taoensso/truss       "1.11.0"]]
+   [com.taoensso/truss       "1.12.0"]]
 
   :profiles
   {;; :default [:base :system :user :provided :dev]
    :provided {:injections   [(println "Lein profile: :provided")]
               :dependencies [[org.clojure/clojurescript "1.11.132"]
                              [org.clojure/clojure       "1.11.4"]]}
-   :c1.12    {:dependencies [[org.clojure/clojure       "1.12.0-rc1"]]}
+   :c1.12    {:dependencies [[org.clojure/clojure       "1.12.0"]]}
    :c1.11    {:dependencies [[org.clojure/clojure       "1.11.4"]]}
    :c1.10    {:dependencies [[org.clojure/clojure       "1.10.3"]]}
    :c1.9     {:dependencies [[org.clojure/clojure       "1.9.0"]]}

--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -3072,7 +3072,7 @@
 
 (let [sentinel (new-object)
       return (fn [m0 v0 m1 v1] (not= v0 v1))]
-  
+
   (defn reset-in!? ; Keys: 0, 1, n (general)
     "Like `reset-in!` but returns true iff the atom's value changed."
     ([atom_              val] (-reset-k0! return atom_              val))
@@ -5089,7 +5089,7 @@
        "Private, don't use. Returns a new stateful `ReseedingSRNG`."
        {:added "Encore v3.75.0 (2024-01-29)"}
        ^ReseedingSRNG []
-       (compile-if        java.security.SecureRandom/getInstanceStrong ; Java 8+, blocking
+       (compile-if        (java.security.SecureRandom/getInstanceStrong) ; Java 8+, blocking
          (ReseedingSRNG. (java.security.SecureRandom/getInstanceStrong)      0)
          (ReseedingSRNG. (java.security.SecureRandom/getInstance "SHA1SRNG") 0)))
 

--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -1193,8 +1193,8 @@
 
            file
            (if-not (:ns macro-env)
-             *file* ; Compiling clj
-             (or    ; Compiling cljs
+             *file* ; Compiling Clj
+             (or    ; Compiling Cljs
                (when-let [url (and file (catching (jio/resource file)))]
                  (catching (.getPath (jio/file url)))
                  (do                 (str      url)))


### PR DESCRIPTION
In Java8+, an exception NoSuchAlgorithmException will be thrown
Change: `(compile-if java.security.SecureRandom/getInstanceStrong ... ...)`  ->  `(compile-if (java.security.SecureRandom/getInstanceStrong) ... ...) `