### PR TITLE
fixed uuid to degrade nicely in RN environments

### DIFF
--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -4722,7 +4722,7 @@
   #?(:clj          (^java.util.UUID []  (java.util.UUID/randomUUID))
      :cljs
      ([]
-      (if-let [f (oget js-?crypto "randomUUID")]
+      (if-let [f (catching (oget js-?crypto "randomUUID"))]
         (.call f js-?crypto)
         (let [^string quad-hex
               (fn []

--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -836,7 +836,7 @@
       - `start` may be -ive (=> index from right of vector).
       - `end`   is desired vector length, or `:max`."
   {:added "Encore v3.126.0 (2024-10-23)"
-   :arglists '([v start-idx] [v start-idx end-idx] [v kind start end])}
+   :arglists '([v start-idx] [v start-idx end-idx] [v :by-len start end])}
   (subfn `subvec core-subvec))
 
 (def* substr
@@ -848,7 +848,7 @@
       - `start` may be -ive (=> index from right of string).
       - `end`   is desired string length, or `:max`."
   {:added "Encore v3.126.0 (2024-10-23)"
-   :arglists '([s start-idx] [s start-idx end-idx] [s kind start end])}
+   :arglists '([s start-idx] [s start-idx end-idx] [s :by-len start end])}
   (subfn `substr (fn [s n1 n2] (.substring #?(:clj ^String s :cljs s) n1 n2))))
 
 (comment


### PR DESCRIPTION
Trying to use sente and encore in node and react native environments. In RN, this uuid function fails with 

TypeError: right operand of 'in' is not an object
    at get (http://localhost:8081/app/goog.object.object.js:149:25)
    at anonymous (http://localhost:8081/app/taoensso.encore.js:2797:51)
    at taoensso$encore$uuid 

I think the supplied patch should fix this.