### PR TITLE
Add clj-kondo hook for defaliases

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,1 +1,1 @@
-{:config-paths ["taoensso/encore"]}
+{:config-paths ["../resources/clj-kondo.exports/taoensso/encore"]}

--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -1,5 +1,6 @@
 {:hooks
  {:analyze-call
   {taoensso.encore/defalias    taoensso.encore/defalias
+   taoensso.encore/defaliases  taoensso.encore/defaliases
    taoensso.encore/defn-cached taoensso.encore/defn-cached
    taoensso.encore/defonce     taoensso.encore/defonce}}}

--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -1,6 +1,6 @@
 {:hooks
  {:analyze-call
-  {taoensso.encore/defalias    taoensso.encore/defalias
-   taoensso.encore/defaliases  taoensso.encore/defaliases
-   taoensso.encore/defn-cached taoensso.encore/defn-cached
-   taoensso.encore/defonce     taoensso.encore/defonce}}}
+  {taoensso.encore/defalias    taoensso.encore-hooks/defalias
+   taoensso.encore/defaliases  taoensso.encore-hooks/defaliases
+   taoensso.encore/defn-cached taoensso.encore-hooks/defn-cached
+   taoensso.encore/defonce     taoensso.encore-hooks/defonce}}}

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore.clj
@@ -19,6 +19,20 @@
           (hooks/token-node (hooks/sexpr src))])
        (meta src))}))
 
+(defn defaliases
+  [{:keys [node]}]
+  (let [alias-nodes (rest (:children node))]
+    {:node
+     (hooks/list-node
+      (into
+       [(hooks/token-node 'do)]
+       (map
+        (fn alias->defalias [alias-node]
+          (hooks/list-node
+           [(hooks/token-node 'taoensso.encore/defalias)
+            alias-node])))
+       alias-nodes))}))
+
 (defn defn-cached
   [{:keys [node]}]
   (let [[sym _opts binding-vec & body] (rest (:children node))]

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore_hooks.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore_hooks.clj
@@ -1,4 +1,4 @@
-(ns taoensso.encore
+(ns taoensso.encore-hooks
   "I don't personally use clj-kondo, so these hooks are
   kindly authored and maintained by contributors.
   PRs very welcome! - Peter Taoussanis"

--- a/resources/clj-kondo.exports/taoensso/encore/taoensso/encore_hooks.clj
+++ b/resources/clj-kondo.exports/taoensso/encore/taoensso/encore_hooks.clj
@@ -28,9 +28,17 @@
        [(hooks/token-node 'do)]
        (map
         (fn alias->defalias [alias-node]
-          (hooks/list-node
-           [(hooks/token-node 'taoensso.encore/defalias)
-            alias-node])))
+          (cond
+            (symbol? (hooks/sexpr alias-node))
+            (hooks/list-node
+             [(hooks/token-node 'taoensso.encore/defalias)
+              alias-node])
+
+            (hooks/map-node? alias-node)
+            (let [{:keys [src alias]} (hooks/sexpr alias-node)]
+              (hooks/list-node
+               [(hooks/token-node 'taoensso.encore/defalias)
+                (symbol (name (hooks/sexpr (or alias src)))) src])))))
        alias-nodes))}))
 
 (defn defn-cached


### PR DESCRIPTION
https://github.com/taoensso/telemere/issues/32

## Why

I moved the hook namespace because it seemed to clash with the main impl: docstrings were getting pulled from the hook namespace

## Proof

Tested with `docker run -v $(pwd):/work -w /work --rm cljkondo/clj-kondo clj-kondo --config .clj-kondo/config.edn --lint src/taoensso/encore/bytes.clj`

### Before
```
src/taoensso/encore/bytes.clj:9:22: warning: Unused import StandardCharsets
src/taoensso/encore/bytes.clj:111:13: warning: redundant do
src/taoensso/encore/bytes.clj:134:10: warning: redundant do
src/taoensso/encore/bytes.clj:218:31: error: Unresolved symbol: utf8-str
src/taoensso/encore/bytes.clj:235:7: error: Unresolved symbol: bytes?
src/taoensso/encore/bytes.clj:236:20: error: Unresolved symbol: str->utf8-ba
src/taoensso/encore/bytes.clj:272:40: error: Unresolved symbol: utf8-ba->str
src/taoensso/encore/bytes.clj:309:11: warning: redundant do
src/taoensso/encore/bytes.clj:350:7: warning: redundant do
src/taoensso/encore/bytes.clj:407:11: warning: redundant do
```

### After
```
src/taoensso/encore/bytes.clj:9:22: warning: Unused import StandardCharsets
src/taoensso/encore/bytes.clj:111:13: warning: redundant do
src/taoensso/encore/bytes.clj:134:10: warning: redundant do
src/taoensso/encore/bytes.clj:309:11: warning: redundant do
src/taoensso/encore/bytes.clj:350:7: warning: redundant do
src/taoensso/encore/bytes.clj:407:11: warning: redundant do
```

The symbols pulled into bytes by [defaliases](https://github.com/valerauko/encore/blob/ef82b21b96e96b09061ff3b91259367ad9e67e20/src/taoensso/encore/bytes.clj#L77-L86) are no longer reported as unresolved