### PR TITLE
Add clj-kondo hook for `def*`

### DIFF
--- a/resources/clj-kondo.exports/taoensso/encore/config.edn
+++ b/resources/clj-kondo.exports/taoensso/encore/config.edn
@@ -3,4 +3,5 @@
   {taoensso.encore/defalias    taoensso.encore-hooks/defalias
    taoensso.encore/defaliases  taoensso.encore-hooks/defaliases
    taoensso.encore/defn-cached taoensso.encore-hooks/defn-cached
-   taoensso.encore/defonce     taoensso.encore-hooks/defonce}}}
+   taoensso.encore/defonce     taoensso.encore-hooks/defonce
+   taoensso.encore/def*        taoensso.encore-hooks/def*}}}

--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -423,7 +423,8 @@
 #?(:clj
    (defmacro def*
      "Like `core/def` but supports attrs map."
-     {:style/indent 1}
+     {:arglists     '([sym doc-string? attr-map? init-expr])
+      :style/indent 1}
      [sym & args]
      (let [[sym body] (name-with-attrs sym args)]
        `(def ~sym ~@body))))
@@ -433,7 +434,8 @@
 #?(:clj
    (defmacro defonce
      "Like `core/defonce` but supports docstring and attrs map."
-     {:style/indent 1}
+     {:arglists     '([sym doc-string? attr-map? init-expr])
+      :style/indent 1}
      [sym & args]
      (let [[sym body] (name-with-attrs sym args)]
        (if (:ns &env)


### PR DESCRIPTION
Hi Peter!

This is a minor and straightforward addendum to PR #77 of mine.
Plus, I dared to introduce `:arglists` to `def*` & `defone` macros.

Cheers,
Mark