### PR TITLE
Fix deref-safely to preserve interrupt flag

### DIFF
--- a/src/taoensso/encore.cljc
+++ b/src/taoensso/encore.cljc
@@ -5711,13 +5711,16 @@
 ;;;; Host info
 
 #?(:clj
-   (defmacro ^:private deref-safely
-     "Like normal blocking deref, but returns `timeout-val` when calling
+   (defmacro ^:no-doc deref-safely
+     "Private, don't use.
+     Like normal blocking deref, but returns `timeout-val` when calling
      thread is interrupted while blocking."
      [p timeout-msecs timeout-val]
      `(try
         (deref ~p ~timeout-msecs ~timeout-val)
-        (catch InterruptedException _# ~timeout-val))))
+        (catch InterruptedException _#
+          (.interrupt (Thread/currentThread))
+          ~timeout-val))))
 
 #?(:clj
    (defn ^:no-doc refreshing-cache

--- a/test/taoensso/encore_tests.cljc
+++ b/test/taoensso/encore_tests.cljc
@@ -1009,6 +1009,24 @@
            (let [ff (enc/format-inst-fn {:formatter java.time.format.DateTimeFormatter/ISO_LOCAL_DATE_TIME})]
              (is (= (ff ref-inst) "2024-06-09T21:15:20.17") "Depends on auto zone")))]))])
 
+#?(:clj
+   (deftest _interrupts
+     (testing "Preserve interrupt flag"
+       (let [t (Thread.
+                (fn []
+                  (enc/deref-safely (promise) 1000 "foo")))]
+         (.start t)
+
+         ;; Wait for thread to block on wait for promise. Then interrupt the thread
+         (loop []
+           (if (= (.getState t) Thread$State/TIMED_WAITING)
+             (.interrupt t)
+             (recur)))
+
+         (.join t)
+
+         (is (true? (.isInterrupted t)))))))
+
 ;;;; Futures
 
 #?(:clj


### PR DESCRIPTION
My team had been using your Telemere library in a highly multithreaded solution. We noticed that on each log call, thread interrupt flag gets reset. So unfortunately we had to move to another logging solution due to this issue.

We dug deeper and found the real culprit of this, `deref-safely`.
If a thread gets interrupted while `deref-safely` is waiting for a value, the interrupt flag gets reset. This is a very dangerous behavior that may throw off multithreaded applications that rely on a well-established thread interruption mechanism that Java provides.

These changes ensure that after `deref-safely` call, the state of interrupt flag is preserved.
There is also a new unit test added to check and enforce this behavior.
